### PR TITLE
Initial support for strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ lisp in rust
 - [X] conditionals
 - [x] relational ops
 - [x] logical ops
-- [ ] strings
+- [x] strings
+- [ ] revamp tokenizer and parser
+    - [ ] strings with spaces in them
+    - [ ] track line and col num for each token
 - [ ] loops
 - [ ] cleanup code
   - [ ] make env more functional

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -24,6 +24,7 @@ pub enum Atom {
     Symbol(String),
     Number(Number),
     Bool(bool),
+    String(String),
 }
 
 impl fmt::Display for Atom {
@@ -32,6 +33,7 @@ impl fmt::Display for Atom {
             Atom::Symbol(string) => write!(f, "{}", string),
             Atom::Number(num) => write!(f, "{}", num),
             Atom::Bool(boolean) => write!(f, "{}", boolean),
+            Atom::String(string) => write!(f, "\"{}\"", string),
         }
     }
 }


### PR DESCRIPTION
Renamed `parse_int` to `parse_atom` since it handles float, symbol too
(and now strings too).
- Decides which to parse based on first char.
    - anything starting with a number or "." is int/float
    - anything starting with a double quote is string
    - everything else is symbol

Added String to Atom.

One big caveat: only strings without spaces in them are supported. This
is because the tokenizer splits on whitespace. So unless that is
changed, we cannot support such string.