### PR TITLE
New tokenizer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [dependencies]
 rustyline = "9.1.0" # for the repl
 home = "0.5.3" # for getting home_dir
+itertools = "0.10.2" # better iterators
 
 [dev-dependencies]
 # benchmarking

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@ pub mod errors;
 pub mod eval;
 
 use std::collections::VecDeque;
+use std::iter::Peekable;
+use std::rc::Rc;
+use std::str::Chars;
 
 use crate::ast::{Atom, Expr, Number};
 use crate::env::Env;
@@ -11,7 +14,7 @@ use crate::errors::{RuntimeError, SpressoError, SyntaxError};
 use crate::eval::execute;
 
 pub fn evaluate_expression(input: String, env: &mut Env) -> Result<Expr, SpressoError> {
-    let mut tokenized_input: VecDeque<String> = tokenize(input);
+    let mut tokenized_input: VecDeque<Token> = tokenize(input);
     let ast = parse(&mut tokenized_input)?;
     match ast {
         Expr::List(mut exprs) => execute(&mut exprs, env),
@@ -22,27 +25,111 @@ pub fn evaluate_expression(input: String, env: &mut Env) -> Result<Expr, Spresso
     }
 }
 
-fn tokenize(input: String) -> VecDeque<String> {
-    let input: String = input.replace("(", " ( ").replace(")", " ) ");
-    let res = input
-        .split_whitespace()
-        .map(|tok| tok.to_string())
-        .collect();
-    return res;
+struct Token {
+    text: String,
+    line_num: usize,
+    col_num_start: usize,
+    col_num_end: usize,
+    program_text: Rc<String>,
 }
 
-fn parse(tokens: &mut VecDeque<String>) -> Result<Expr, SyntaxError> {
+fn tokenize(input: String) -> VecDeque<Token> {
+    let program_text = Rc::new(input);
+    let mut tokens = VecDeque::new();
+
+    let mut line_num = 1;
+    let mut col_num = 1;
+
+    let char_processor = |c: char,
+                          chars: &mut Peekable<Chars>,
+                          line_num: &mut usize,
+                          col_num: &mut usize|
+     -> Option<String> {
+        let mut new_token = String::from(c);
+        match c {
+            '(' => Some(new_token),
+            ')' => Some(new_token),
+            '0'..='9' | '.' => {
+                loop {
+                    // TODO: ensure only one "." in number
+                    match chars.peek() {
+                        Some('0'..='9') | Some('.') => new_token.push(chars.next().unwrap()),
+                        Some(_) => break,
+                        None => break,
+                    }
+                }
+
+                Some(new_token)
+            }
+            ' ' => {
+                *col_num += 1;
+                None
+            }
+            '\n' => {
+                *line_num += 1;
+                *col_num = 1;
+                None
+            }
+            '"' => {
+                loop {
+                    match chars.peek() {
+                        Some('"') => {
+                            new_token.push(chars.next().unwrap());
+                            break;
+                        }
+                        Some(_) => new_token.push(chars.next().unwrap()),
+                        None => break,
+                    }
+                }
+
+                Some(new_token)
+            }
+            _ => {
+                loop {
+                    match chars.peek() {
+                        Some(' ' | '\n' | '(' | ')') => break,
+                        Some(_) => new_token.push(chars.next().unwrap()),
+                        None => break,
+                    }
+                }
+
+                Some(new_token)
+            }
+        }
+    };
+
+    let program_text = Rc::clone(&program_text);
+    let mut chars = program_text.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        let col_num_start = col_num;
+        if let Some(new_token) = char_processor(c, &mut chars, &mut line_num, &mut col_num) {
+            let col_num_end = col_num + new_token.len();
+            tokens.push_back(Token {
+                text: new_token,
+                line_num,
+                col_num_start,
+                col_num_end,
+                program_text: Rc::clone(&program_text),
+            })
+        }
+    }
+
+    tokens
+}
+
+fn parse(tokens: &mut VecDeque<Token>) -> Result<Expr, SyntaxError> {
     let token = match tokens.pop_front() {
         Some(token) => token,
         // no tokens (vec was empty)
         None => return Err(SyntaxError::from("Unexpected EOF".to_string())),
     };
 
-    match token.as_str() {
+    match token.text.as_str() {
         "(" => {
             // collect everything before ")"
             let mut ast: Vec<Expr> = Vec::new();
-            while !tokens.is_empty() && tokens[0] != ")" {
+            while !tokens.is_empty() && tokens[0].text != ")" {
                 // recursively parse each of them
                 let inner_ast = parse(tokens)?;
                 ast.push(inner_ast);
@@ -56,7 +143,7 @@ fn parse(tokens: &mut VecDeque<String>) -> Result<Expr, SyntaxError> {
             return Ok(Expr::List(ast));
         }
         ")" => return Err(SyntaxError::from("Unexpected ')'")),
-        _ => Ok(Expr::Atom(parse_atom(token)?)),
+        _ => Ok(Expr::Atom(parse_atom(token.text)?)),
     }
 }
 
@@ -77,7 +164,7 @@ fn parse_atom(token: String) -> Result<Atom, SyntaxError> {
             }
 
             Err(SyntaxError::from("Symbols cannot start with a number"))
-        },
+        }
         '"' => {
             let str_without_quotes = match token.strip_suffix("\"") {
                 Some(s) => s,
@@ -89,6 +176,6 @@ fn parse_atom(token: String) -> Result<Atom, SyntaxError> {
 
             Ok(Atom::String(str_without_quotes.to_string()))
         }
-        _ => Ok(Atom::Symbol(token))
+        _ => Ok(Atom::Symbol(token)),
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,8 @@ fn tokenize(input: String) -> VecDeque<Token> {
                 // take everything until some other token is found
                 // TODO: move this set of chars somewhere else
                 let new_chars = chars.peeking_take_while(|c| match c {
-                    ' ' | '\n' | '(' | ')' => true,
-                    _ => false,
+                    ' ' | '\n' | '(' | ')' => false,
+                    _ => true,
                 });
                 new_token.extend(new_chars);
 

--- a/tests/string_test.rs
+++ b/tests/string_test.rs
@@ -1,0 +1,37 @@
+use spressolisp::{ast::{Number, Expr, Atom}, env::Env, eval::extract_num, evaluate_expression};
+
+#[test]
+fn test_string_nospace() {
+    let mut env = Env::new();
+    if let Ok(_) = evaluate_expression("(define x \"helloworld\")".to_string(), &mut env) {
+        if let Ok(res) = evaluate_expression("(x)".to_string(), &mut env) {
+            if let Expr::Atom(Atom::String(s)) = res {
+                assert_eq!(s, "helloworld");
+            } else {
+                assert!(false, "Result is not an integer");
+            }
+        } else {
+            assert!(false, "Error evaluating expression");
+        }
+    } else {
+        assert!(false, "Error evaluating expression");
+    }
+}
+
+#[test]
+fn test_string_space() {
+    let mut env = Env::new();
+    if let Ok(_) = evaluate_expression("(define x \"hello world\")".to_string(), &mut env) {
+        if let Ok(res) = evaluate_expression("(x)".to_string(), &mut env) {
+            if let Expr::Atom(Atom::String(s)) = res {
+                assert_eq!(s, "hello world");
+            } else {
+                assert!(false, "Result is not an integer");
+            }
+        } else {
+            assert!(false, "Error evaluating expression");
+        }
+    } else {
+        assert!(false, "Error evaluating expression");
+    }
+}


### PR DESCRIPTION
The new tokenizer is just a bunch of `match`es and `loop`s (and `take_while`s). It can
handle:
- Parentheses
- Spaces and newlines
- Strings
- Everything else is an identifier (symbol)

Instead of String, the tokenizer gives a Token which keeps track of line
number, column number (both start and end) and also stores a reference
to the original text (which can be used to print errors, etc.)

As of now, the other fields aren't used (so you will see many warnings).

This fixes the issue where strings could not have spaces in them.

Though there is one issue: the number token does not ensure that there's
only one "." in the string.

---

Also added some tests for strings.