### PR TITLE
25 Adding clippy checks on CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,3 +22,6 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Check clippy
+      if: ${{ always() }}
+      run: cargo clippy --all-targets --all-features -- -D warnings


### PR DESCRIPTION
# Description

Added the support to running Clippy during the CI process, to improve the repository code quality. The usage of the always flag allows us to check the Clippy even if the tests fail, for example, allowing us to correct more than one problem in the next commit.

Fixes part of #25

## Type of change
- [X] Feature